### PR TITLE
Add mailroom 7.4

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       GREP_TIMEOUT: 60
     strategy:
       matrix:
-        MAILROOM_VERSION: ["6.0.3", "6.2.3", "6.4.3", "7.0.1", "7.2.6"]
+        MAILROOM_VERSION: ["6.0.3", "6.2.3", "6.4.3", "7.0.1", "7.2.6", "7.4.1"]
     steps:
       - uses: actions/checkout@v2
       - uses: docker/setup-buildx-action@v1


### PR DESCRIPTION
Add the officially supported version for RapidPro 7.4.2