### PR TITLE
Change repo to rapidpro/mailroom

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      MAILROOM_REPO: nyaruka/mailroom
+      MAILROOM_REPO: rapidpro/mailroom
       GREP_TIMEOUT: 60
     strategy:
       matrix:


### PR DESCRIPTION
It seems like this has changed upstream, and all the releases are now in
rapidpro/mailroom
